### PR TITLE
Fix getUnjailedPath() is called multiple times

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Jail.php
+++ b/lib/private/Files/Storage/Wrapper/Jail.php
@@ -344,6 +344,10 @@ class Jail extends Wrapper {
 		return $this->getWrapperStorage()->free_space($this->getUnjailedPath($path));
 	}
 
+	public function free_space_skip_unjail_path($path) {
+		return $this->getWrapperStorage()->free_space($path);
+	}
+
 	/**
 	 * search for occurrences of $query in file names
 	 *

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -334,6 +334,10 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 		return $this->getWrapperStorage()->free_space($path);
 	}
 
+	public function free_space_skip_unjail_path($path) {
+		return $this->getWrapperStorage()->free_space_skip_unjail_path($path);
+	}
+
 	/**
 	 * search for occurrences of $query in file names
 	 *

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -517,8 +517,10 @@ class OC_Helper {
 		$mount = $rootInfo->getMountPoint();
 		$storage = $mount->getStorage();
 		$sourceStorage = $storage;
+		$skipUnjailPath = false;
 		if ($storage->instanceOfStorage('\OCA\Files_Sharing\SharedStorage')) {
 			$includeExtStorage = false;
+			$skipUnjailPath = true;
 			$internalPath = $storage->getUnjailedPath($rootInfo->getInternalPath());
 		} else {
 			$internalPath = $rootInfo->getInternalPath();
@@ -545,7 +547,11 @@ class OC_Helper {
 			$quota = $sourceStorage->getQuota();
 		}
 		try {
-			$free = $sourceStorage->free_space($internalPath);
+			if ($skipUnjailPath === True) {
+				$free = $sourceStorage->free_space_skip_unjail_path($internalPath);
+			} else {
+				$free = $sourceStorage->free_space($internalPath);
+			}
 		} catch (\Exception $e) {
 			if ($path === "") {
 				throw $e;


### PR DESCRIPTION
See [#32178](https://github.com/nextcloud/server/issues/32178) for more details. 
With shared storage, getUnjailedPath() unexpectedly runs twice in [OC_Helper.getStorageInfo](https://github.com/nextcloud/server/blob/master/lib/private/legacy/OC_Helper.php#L522) and [Jail.free_space](https://github.com/nextcloud/server/blob/master/lib/private/Files/Storage/Wrapper/Jail.php#L344). This duplicates some parts of the path (example [here](https://github.com/nextcloud/server/issues/32178#issuecomment-1115768616)). The solution is to create free_space_skip_unjail_path and use it when needed. 
Fix [#32178](https://github.com/nextcloud/server/issues/32178)